### PR TITLE
ヘルプの向け先を Redmine の wiki に設定しました

### DIFF
--- a/src/main/java/hoshisugi/rukoru/app/view/MainController.java
+++ b/src/main/java/hoshisugi/rukoru/app/view/MainController.java
@@ -30,7 +30,8 @@ public class MainController extends BaseController {
 
 	@FXML
 	private void onHelp(final ActionEvent event) throws Exception {
-		BrowserUtil.browse(/* TODO あとでURL決める */"http://www.google.com");
+		BrowserUtil.browse(
+				"http://redmine.dataspidercloud.tokyo/projects/dataspidercloud/wiki/%E6%98%9F%E6%9D%89%E2%98%86%E3%82%8B%E3%81%93%E3%82%8B");
 	}
 
 	@FXML


### PR DESCRIPTION
## 対応内容

Redmine の wiki に作成したるこるのヘルプページを作成し、メニュー > ヘルプ の遷移先をそちらに設定しました。