### PR TITLE
AMI の作成日を Asia/Tokyo で表示するようにした

### DIFF
--- a/src/main/java/hoshisugi/rukoru/app/models/ec2/MachineImage.java
+++ b/src/main/java/hoshisugi/rukoru/app/models/ec2/MachineImage.java
@@ -3,7 +3,8 @@ package hoshisugi.rukoru.app.models.ec2;
 import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
 
 import java.io.Serializable;
-import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
 import com.amazonaws.services.ec2.model.Image;
@@ -31,7 +32,7 @@ public class MachineImage implements Serializable {
 		setImageId(image.getImageId());
 		setName(image.getName());
 		setState(image.getState());
-		setCreationDate(formatter.format(LocalDateTime.parse(image.getCreationDate(), ISO_DATE_TIME)));
+		setCreationDate(toDefaultZonedDateTime(image.getCreationDate()).format(formatter));
 	}
 
 	public String getImageId() {
@@ -82,4 +83,8 @@ public class MachineImage implements Serializable {
 		return creationDate;
 	}
 
+	private ZonedDateTime toDefaultZonedDateTime(final String isoDateTime) {
+		final ZonedDateTime utc = ZonedDateTime.parse(isoDateTime, ISO_DATE_TIME);
+		return utc.withZoneSameInstant(ZoneId.systemDefault());
+	}
 }


### PR DESCRIPTION
## 内容

AMI の作成日が UTC で表示されていたので、Asia/Tokyo で表示するように修正しました。