### PR TITLE
リフレッシュしなくても EC2 インスタンスの IP アドレスが表示されるようにした。

### DIFF
--- a/src/main/java/hoshisugi/rukoru/app/view/ec2/InstanceTabController.java
+++ b/src/main/java/hoshisugi/rukoru/app/view/ec2/InstanceTabController.java
@@ -1,7 +1,6 @@
 package hoshisugi.rukoru.app.view.ec2;
 
 import static hoshisugi.rukoru.framework.util.AssetUtil.getImage;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static javafx.beans.binding.Bindings.when;
 
 import java.net.URL;
@@ -11,8 +10,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.ResourceBundle;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Strings;
@@ -44,7 +41,6 @@ import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
-import javafx.scene.control.Tooltip;
 import javafx.scene.control.cell.CheckBoxTableCell;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.Clipboard;
@@ -137,14 +133,7 @@ public class InstanceTabController extends BaseController {
 		final ClipboardContent content = new ClipboardContent();
 		content.putString(button.getText());
 		Clipboard.getSystemClipboard().setContent(content);
-		final Tooltip tooltip = new Tooltip("クリップボードにコピーしました。");
-		tooltip.setAutoHide(true);
-		tooltip.show(FXUtil.getStage(event));
-		final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
-		scheduler.schedule(() -> {
-			Platform.runLater(() -> tooltip.hide());
-			scheduler.shutdown();
-		}, 1000, MILLISECONDS);
+		FXUtil.showTooltip("クリップボードにコピーしました。", event);
 	}
 
 	private Button createImageButton(final EC2Instance entity) {

--- a/src/main/java/hoshisugi/rukoru/app/view/ec2/InstanceTabController.java
+++ b/src/main/java/hoshisugi/rukoru/app/view/ec2/InstanceTabController.java
@@ -66,7 +66,7 @@ public class InstanceTabController extends BaseController {
 	private TableColumn<EC2Instance, String> stateColumn;
 
 	@FXML
-	private TableColumn<EC2Instance, EC2Instance> publicIpAddressColumn;
+	private TableColumn<EC2Instance, String> publicIpAddressColumn;
 
 	@FXML
 	private TableColumn<EC2Instance, EC2Instance> runAndStopColumn;
@@ -98,7 +98,6 @@ public class InstanceTabController extends BaseController {
 	@Override
 	public void initialize(final URL url, final ResourceBundle resource) {
 		stateColumn.setCellFactory(TextFillTableCell.forTableCellFactory(this::provideColor));
-		publicIpAddressColumn.setCellValueFactory(GraphicTableCell.forTableCellValueFactory());
 		publicIpAddressColumn.setCellFactory(GraphicTableCell.forTableCellFactory(this::createPublicIpAddressButton));
 		autoStopColumn.setCellFactory(CheckBoxTableCell.forTableColumn(autoStopColumn));
 		runAndStopColumn.setCellValueFactory(GraphicTableCell.forTableCellValueFactory());
@@ -179,14 +178,13 @@ public class InstanceTabController extends BaseController {
 		return button;
 	}
 
-	private Button createPublicIpAddressButton(final EC2Instance entity) {
-		if (Strings.isNullOrEmpty(entity.getPublicIpAddress())) {
+	private Button createPublicIpAddressButton(final String publicIpAddress) {
+		if (Strings.isNullOrEmpty(publicIpAddress)) {
 			return null;
 		}
 		final Button button = new Button();
-		button.setText(entity.getPublicIpAddress());
+		button.setText(publicIpAddress);
 		button.setOnAction(this::onCopyButtonClick);
-		button.setUserData(entity);
 		return button;
 	}
 

--- a/src/main/java/hoshisugi/rukoru/app/view/ec2/InstanceTabView.fxml
+++ b/src/main/java/hoshisugi/rukoru/app/view/ec2/InstanceTabView.fxml
@@ -31,7 +31,11 @@
       				</TableColumn>
       				<TableColumn fx:id="runAndStopColumn" maxWidth="1.7976931348623157E308" minWidth="80.0" text="起動/停止">
 				</TableColumn>
-      				<TableColumn fx:id="publicIpAddressColumn" maxWidth="1.7976931348623157E308" minWidth="110.0" prefWidth="110.0" text="IPアドレス" />
+      				<TableColumn fx:id="publicIpAddressColumn" maxWidth="1.7976931348623157E308" minWidth="110.0" prefWidth="110.0" text="IPアドレス">
+      					<cellValueFactory>
+      						<PropertyValueFactory property="publicIpAddress" />
+      					</cellValueFactory>
+      				</TableColumn>
       				<TableColumn fx:id="instanceTypeColumn" maxWidth="1.7976931348623157E308" minWidth="100.0" prefWidth="100.0" text="インスタンスタイプ">
       					<cellValueFactory>
       						<PropertyValueFactory property="instanceType" />

--- a/src/main/java/hoshisugi/rukoru/app/view/repositorydb/RepositoryDBContentController.java
+++ b/src/main/java/hoshisugi/rukoru/app/view/repositorydb/RepositoryDBContentController.java
@@ -1,13 +1,9 @@
 package hoshisugi.rukoru.app.view.repositorydb;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-
 import java.net.URL;
 import java.sql.SQLException;
 import java.util.Optional;
 import java.util.ResourceBundle;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 
 import com.google.common.base.Strings;
 import com.google.inject.Inject;
@@ -32,7 +28,6 @@ import javafx.scene.control.ButtonType;
 import javafx.scene.control.SelectionMode;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
-import javafx.scene.control.Tooltip;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
@@ -151,13 +146,6 @@ public class RepositoryDBContentController extends BaseController {
 		final RepositoryDB db = (RepositoryDB) button.getUserData();
 		content.putString(db.getName());
 		Clipboard.getSystemClipboard().setContent(content);
-		final Tooltip tooltip = new Tooltip("クリップボードにコピーしました。");
-		tooltip.setAutoHide(true);
-		tooltip.show(FXUtil.getStage(event));
-		final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
-		scheduler.schedule(() -> {
-			Platform.runLater(() -> tooltip.hide());
-			scheduler.shutdown();
-		}, 1000, MILLISECONDS);
+		FXUtil.showTooltip("クリップボードにコピーしました。", event);
 	}
 }

--- a/src/main/java/hoshisugi/rukoru/framework/controls/GraphicTableCell.java
+++ b/src/main/java/hoshisugi/rukoru/framework/controls/GraphicTableCell.java
@@ -10,25 +10,25 @@ import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableColumn.CellDataFeatures;
 import javafx.util.Callback;
 
-public class GraphicTableCell<S> extends TableCell<S, S> {
+public class GraphicTableCell<S, T> extends TableCell<S, T> {
 
-	private final Function<S, ? extends Node> nodeProvider;
+	private final Function<T, ? extends Node> nodeProvider;
 
 	public static <S> Callback<CellDataFeatures<S, S>, ObservableValue<S>> forTableCellValueFactory() {
 		return param -> new ReadOnlyObjectWrapper<>(param.getValue());
 	}
 
-	public static <S> Callback<TableColumn<S, S>, TableCell<S, S>> forTableCellFactory(
-			final Function<S, ? extends Node> nodeProvider) {
+	public static <S, T> Callback<TableColumn<S, T>, TableCell<S, T>> forTableCellFactory(
+			final Function<T, ? extends Node> nodeProvider) {
 		return item -> new GraphicTableCell<>(nodeProvider);
 	}
 
-	public GraphicTableCell(final Function<S, ? extends Node> nodeProvider) {
+	public GraphicTableCell(final Function<T, ? extends Node> nodeProvider) {
 		this.nodeProvider = nodeProvider;
 	}
 
 	@Override
-	protected void updateItem(final S item, final boolean empty) {
+	protected void updateItem(final T item, final boolean empty) {
 		super.updateItem(item, empty);
 		if (!empty && item != null) {
 			final Node node = nodeProvider.apply(item);

--- a/src/main/java/hoshisugi/rukoru/framework/util/FXUtil.java
+++ b/src/main/java/hoshisugi/rukoru/framework/util/FXUtil.java
@@ -1,21 +1,27 @@
 package hoshisugi.rukoru.framework.util;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URL;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 
 import com.google.common.base.Strings;
 
 import hoshisugi.rukoru.framework.annotations.FXController;
 import hoshisugi.rukoru.framework.base.BaseController;
+import javafx.application.Platform;
 import javafx.event.Event;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.MenuItem;
+import javafx.scene.control.Tooltip;
 import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import javafx.stage.Modality;
@@ -113,5 +119,16 @@ public class FXUtil {
 
 	public static Stage getPrimaryStage() {
 		return primaryStage;
+	}
+
+	public static void showTooltip(final String message, final Event event) {
+		final Tooltip tooltip = new Tooltip(message);
+		tooltip.setAutoHide(true);
+		tooltip.show(FXUtil.getStage(event));
+		final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+		scheduler.schedule(() -> {
+			Platform.runLater(() -> tooltip.hide());
+			scheduler.shutdown();
+		}, 1000, MILLISECONDS);
 	}
 }


### PR DESCRIPTION
## 内容

EC2 インスタンスを起動した際、リフレッシュしないと IP アドレスが表示されない不具合を修正した。

原因は IP アドレス列の TableColumn の値に EC2Instance (モデル) 自体を指定していたため。
これを publicIpAddress (StringProperty) に変更したことで、Service からの値変更が GUI にリアルタイムで反映されるようになった。