### PR TITLE
S3 へのアップロード時に content-type を設定するようにした

### DIFF
--- a/src/main/java/hoshisugi/rukoru/app/services/s3/S3ServiceImpl.java
+++ b/src/main/java/hoshisugi/rukoru/app/services/s3/S3ServiceImpl.java
@@ -15,6 +15,7 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URLConnection;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -142,6 +143,7 @@ public class S3ServiceImpl extends BaseService implements S3Service {
 		final AmazonS3 client = createClient();
 		final ObjectMetadata metadata = new ObjectMetadata();
 		metadata.setContentLength(Files.size(path));
+		metadata.setContentType(URLConnection.guessContentTypeFromName(path.toString()));
 
 		final UploadObjectResult result = new UploadObjectResult();
 		result.setName(path.getFileName().toString());


### PR DESCRIPTION
## 内容
S3 にファイルをアップロードする際、ファイルパスから content-type を推測して設定するようにした。

これまではるこるから HTML ファイルや png 画像等をアップロードすると、content-type がすべて`application/octet-stream`としてアップロードされていた。
そのため右クリックメニューの「開く」で開こうとすると、ブラウザで開けずにファイルとしてダウンロードされていた（ブラウザによるかも）。

アップロード時にファイルの拡張子から content-type を推測してアップロードすることで、ブラウザで開けるようになります。