### PR TITLE
S3 エクスプローラの日付書式を yyyy/MM/dd HH:mm:ss にした

### DIFF
--- a/src/main/java/hoshisugi/rukoru/app/models/ec2/EC2Instance.java
+++ b/src/main/java/hoshisugi/rukoru/app/models/ec2/EC2Instance.java
@@ -1,24 +1,19 @@
 package hoshisugi.rukoru.app.models.ec2;
 
 import java.io.Serializable;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.util.Date;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.Tag;
 
+import hoshisugi.rukoru.framework.util.DateTimeUtil;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 
 public class EC2Instance implements Serializable {
-
-	private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss");
 
 	private final StringProperty instanceId = new SimpleStringProperty(this, "instanceId");
 	private final StringProperty name = new SimpleStringProperty(this, "name");
@@ -42,7 +37,7 @@ public class EC2Instance implements Serializable {
 		setAutoStop(Boolean.parseBoolean(tags.get("AutoStop")));
 		setInstanceType(instance.getInstanceType());
 		setPublicIpAddress(instance.getPublicIpAddress());
-		setLaunchTime(formatter.format(toDateTime(instance.getLaunchTime())));
+		setLaunchTime(DateTimeUtil.toString(instance.getLaunchTime()));
 		setState(instance.getState().getName());
 	}
 
@@ -132,10 +127,6 @@ public class EC2Instance implements Serializable {
 
 	private Map<String, String> createTagMap(final Instance instance) {
 		return instance.getTags().stream().collect(Collectors.toMap(Tag::getKey, Tag::getValue));
-	}
-
-	private LocalDateTime toDateTime(final Date launchTime) {
-		return LocalDateTime.ofInstant(launchTime.toInstant(), ZoneId.systemDefault());
 	}
 
 }

--- a/src/main/java/hoshisugi/rukoru/app/models/s3/S3Bucket.java
+++ b/src/main/java/hoshisugi/rukoru/app/models/s3/S3Bucket.java
@@ -5,6 +5,7 @@ import static hoshisugi.rukoru.app.models.s3.S3Item.Type.Bucket;
 import com.amazonaws.services.s3.model.Bucket;
 
 import hoshisugi.rukoru.framework.util.AssetUtil;
+import hoshisugi.rukoru.framework.util.DateTimeUtil;
 import javafx.scene.image.Image;
 
 public class S3Bucket extends S3Item {
@@ -12,7 +13,7 @@ public class S3Bucket extends S3Item {
 	public S3Bucket(final Bucket bucket) {
 		setBucketName(bucket.getName());
 		setName(bucket.getName());
-		setLastModified(bucket.getCreationDate());
+		setLastModified(DateTimeUtil.toString(bucket.getCreationDate()));
 		if (bucket.getOwner() != null) {
 			setOwner(bucket.getOwner().getDisplayName());
 		}

--- a/src/main/java/hoshisugi/rukoru/app/models/s3/S3Item.java
+++ b/src/main/java/hoshisugi/rukoru/app/models/s3/S3Item.java
@@ -1,7 +1,6 @@
 package hoshisugi.rukoru.app.models.s3;
 
 import java.util.Comparator;
-import java.util.Date;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Strings;
@@ -25,7 +24,7 @@ public abstract class S3Item {
 	private final StringProperty bucketName = new SimpleStringProperty(this, "bucketName");
 	private final StringProperty key = new SimpleStringProperty(this, "key");
 	private final StringProperty name = new SimpleStringProperty(this, "name");
-	private final ObjectProperty<Date> lastModified = new SimpleObjectProperty<>(this, "lastModified");
+	private final StringProperty lastModified = new SimpleStringProperty(this, "lastModified");
 	private final ObjectProperty<Long> size = new SimpleObjectProperty<>(this, "size");
 	private final StringProperty storageClass = new SimpleStringProperty(this, "storageClass");
 	private final StringProperty owner = new SimpleStringProperty(this, "owner");
@@ -73,11 +72,11 @@ public abstract class S3Item {
 		}
 	}
 
-	public Date getLastModified() {
+	public String getLastModified() {
 		return lastModified.get();
 	}
 
-	public void setLastModified(final Date lastModified) {
+	public void setLastModified(final String lastModified) {
 		this.lastModified.set(lastModified);
 	}
 
@@ -125,7 +124,7 @@ public abstract class S3Item {
 		return name;
 	}
 
-	public ObjectProperty<Date> lastModifiedProperty() {
+	public StringProperty lastModifiedProperty() {
 		return lastModified;
 	}
 

--- a/src/main/java/hoshisugi/rukoru/app/models/s3/S3Object.java
+++ b/src/main/java/hoshisugi/rukoru/app/models/s3/S3Object.java
@@ -5,6 +5,7 @@ import static hoshisugi.rukoru.app.models.s3.S3Item.Type.Object;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 
 import hoshisugi.rukoru.framework.util.AssetUtil;
+import hoshisugi.rukoru.framework.util.DateTimeUtil;
 import javafx.scene.image.Image;
 
 public class S3Object extends S3Item {
@@ -16,7 +17,7 @@ public class S3Object extends S3Item {
 		setBucketName(object.getBucketName());
 		setKey(object.getKey());
 		setName(object.getKey());
-		setLastModified(object.getLastModified());
+		setLastModified(DateTimeUtil.toString(object.getLastModified()));
 		setSize(object.getSize());
 		setStorageClass(object.getStorageClass());
 		setOwner(object.getOwner().getDisplayName());

--- a/src/main/java/hoshisugi/rukoru/framework/util/DateTimeUtil.java
+++ b/src/main/java/hoshisugi/rukoru/framework/util/DateTimeUtil.java
@@ -1,0 +1,19 @@
+package hoshisugi.rukoru.framework.util;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+public class DateTimeUtil {
+
+	private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss");
+
+	public static ZonedDateTime toDateTime(final Date date) {
+		return ZonedDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault());
+	}
+
+	public static String toString(final Date date) {
+		return formatter.format(toDateTime(date));
+	}
+}


### PR DESCRIPTION
## 内容

S3 エクスプローラに表示する日付書式が ISO_DATE_TIME だったので、"yyyy/MM/dd HH:mm:ss" の書式で表示するようにした。