### PR TITLE
DS インスタンスを 11 件以上登録できない不具合を修正

### DIFF
--- a/src/main/java/hoshisugi/rukoru/app/services/settings/LocalSettingServiceImpl.java
+++ b/src/main/java/hoshisugi/rukoru/app/services/settings/LocalSettingServiceImpl.java
@@ -229,8 +229,9 @@ public class LocalSettingServiceImpl extends BaseService implements LocalSetting
 	private void insertDSSettingsToPreferences(final H2Database h2, final DSSetting setting, final String sequence)
 			throws SQLException {
 		final int nextKey = h2
-				.find(SelectBuilder.query("select MAX(key) from preferences where category='DSSetting'"), this::getInt)
-				.get() + 1;
+				.find(SelectBuilder.query(
+						"select MAX(CAST(key AS INT)) + 1 from preferences where category='DSSetting'"), this::getInt)
+				.get();
 		final Preference p = new Preference("DSSetting", Integer.toString(nextKey), sequence);
 		savePreferences(Arrays.asList(p));
 	}

--- a/src/main/resources/sql/select_ds_settings.sql
+++ b/src/main/resources/sql/select_ds_settings.sql
@@ -12,4 +12,4 @@ inner join ds_settings
   on  preferences.category = 'DSSetting'
   and ds_settings.id = preferences.value
 order by
-  preferences.key
+  cast(preferences.key as int)


### PR DESCRIPTION
preference のキーを `max(key)` で取得していた箇所で、key (varchar) を数値に変換していなかったために 
"10" 以上の数値よりも "9" のほうが大きいとみなされていた。
取得した key の最大値があやまりであったために、インスタンスを 11 件以上登録できなかった不具合を修正した。

また同じ原因でインスタンスのソート順が key の数値順ではなく、ASCII 順となっていた不具合もあわせて修正した。