### PR TITLE
gradlew runApp で起動するようにしました。

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,19 @@ dependencies {
     testRuntime 'org.junit.platform:junit-platform-launcher:1.0.2'
 }
 
+sourceSets {
+    main {
+        resources {
+            srcDir "src/main/java"
+        }
+    }
+}
+
+task runApp(type: JavaExec) {
+    classpath = sourceSets.main.runtimeClasspath
+    main = 'hoshisugi.rukoru.Main'
+}
+
 task wrapper(type: Wrapper) {
     gradleVersion = '4.4'
     distributionUrl = 'https://services.gradle.org/distributions/gradle-4.4-all.zip'


### PR DESCRIPTION
`gradlew runApp` で起動するようにしました。

実装上の補足:

- fxmlファイルが `src/main/java` に置かれているため、 `src/main/java` もresourceとして扱うようにしました。
  - `JavaExec` は https://docs.gradle.org/4.4/dsl/org.gradle.api.tasks.JavaExec.html の通りにしました。
  - `srcDir` は追記なので、デフォルトの `src/main/resources` は残ります。
    - https://docs.gradle.org/4.4/dsl/org.gradle.api.file.SourceDirectorySet.html#org.gradle.api.file.SourceDirectorySet:srcDir(java.lang.Object)
    - `*.java` は標準( https://github.com/gradle/gradle/blob/v4.4.0/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSet.java#L64 )でexcludeされているので、src/main/java 内の `*.java` がリソースとして扱われることはありません。
